### PR TITLE
fix: Use lowercase `package-lock.json` for title

### DIFF
--- a/review/npm.md
+++ b/review/npm.md
@@ -181,7 +181,7 @@ change to the dependency would be detected and rejected.
 
 Npm provides two options to achieve hash pinning.
 
-##### Package-lock.json
+##### package-lock.json
 
 The
 [package-lock.json](https://docs.npmjs.com/cli/v6/configuring-npm/package-lock-json)


### PR DESCRIPTION
I missed this in https://github.com/ossf/package-manager-best-practices/pull/26.
I think the title should also be lowercase in this specific case