### PR TITLE
docs: fix spelling issue for reproducible installs

### DIFF
--- a/published/npm.md
+++ b/published/npm.md
@@ -140,7 +140,7 @@ benefits, including:
 - Ensuring the dependencies installed are the ones declared and reviewed via
   pull requests.
 
-- Helping quickly indentify possible compromises of your infrastructure if one
+- Helping quickly identify possible compromises of your infrastructure if one
   of your dependencies is found to have vulnerabilities, as you will be able to
   promptly determine the commit range of when your repository is at risk.
 


### PR DESCRIPTION
Caught a misspelled word that got added in the last docs review. Context here: https://github.com/ossf/package-manager-best-practices/pull/31#discussion_r970771965

cc @laurentsimon 

Signed-off-by: Liran Tal <liran.tal@gmail.com>