### PR TITLE
feat: added reference to email exposure through the NPM API

### DIFF
--- a/published/npm.md
+++ b/published/npm.md
@@ -431,6 +431,9 @@ download.
 
 3. Consumers of public packages may fall victim to typosquatting attempts. To
    mitigate this problem, and create and own your organization on other registries.
+   
+4. The emails associated with the publisher account and the maintainers (who 
+   can publish) are exposed in the npm API as part of the metadata.
 
 **Note**:
 


### PR DESCRIPTION
### TL;DR
The current [NPM API](https://registry.npmjs.org) is exposing under the `maintainers` and `_npmUser` properties the email addresses of the package maintainers and the author of the release publication.

### Example
Here is an example of it with [Express@4.18.1](https://github.com/expressjs/express/blob/master/package.json):
- The current `package.json` includes some email addresses for `author` and `contributors`. [See](https://github.com/expressjs/express/blob/master/package.json)
- The API also includes the `maintainers` and `_npmUser` information that is not included in the `package.json`. [see](https://registry.npmjs.org/express/4.18.1)

These extra fields were not part of the API in the past (for example [Express@2.5.0](https://registry.npmjs.org/express/2.5.0)) and most npm users are not aware of this change.

The same exposure applies if the package does not include any email in the `author` or `contributors` in the `package.json`.

Currently NPM does not include any way to prevent that. In the past we had a similar situation with Github commits authority, but they provides now the option to use a privacy version like `<username>@users.noreply.github.com` as the email address. [See](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address)
